### PR TITLE
Linkify URLs in article window

### DIFF
--- a/src/more_speech/ui/formatters.clj
+++ b/src/more_speech/ui/formatters.clj
@@ -1,7 +1,6 @@
 (ns more-speech.ui.formatters
   (:require [clojure.string :as string]
             [more-speech.nostr.util :as util]
-            [more-speech.config :as config]
             [more-speech.ui.swing.ui-context :refer :all]
             [more-speech.nostr.events :as events]
             )
@@ -24,27 +23,6 @@
   (let [lines (string/split-lines text)
         lines (map #(str ">" %) lines)]
     (string/join "\n" lines)))
-
-(defn reformat-article [article width]
-  (let [first-line-end (.indexOf article "\n")
-        reply-line? (and (> first-line-end 0) (= \> (first article)))
-        blank-line (.lastIndexOf article "\n\n" width)
-        indentation (.indexOf article "\n ")
-        breakable-space (.lastIndexOf article " " width)
-        [break-point break-string skip]
-        (cond
-          reply-line? [first-line-end "\n" 1]
-          (< -1 indentation width) [indentation "\n " 2]
-          (>= blank-line 0) [blank-line "\n\n" 2]
-          (<= (count article) width) [(count article) "" 0]
-          (>= breakable-space 0) [breakable-space "\n" 1]
-          :else [width "\n" 0])]
-    (let [head (.substring article 0 break-point)
-          head (.replaceAll head "\n" " ")
-          tail (.substring article (+ skip break-point))]
-      (if (empty? tail)
-        head
-        (str head break-string (reformat-article tail width))))))
 
 (defn format-user-id [nicknames user-id]
   (if (nil? user-id)
@@ -71,7 +49,7 @@
 
 (defn format-reply [event]
   (let [content (replace-references event)]
-    (prepend> (reformat-article content config/article-width))))
+    (prepend> content)))
 
 (defn get-subject [tags]
   (if (empty? tags)
@@ -112,3 +90,52 @@
                    name)]
         (str "@" name)))))
 
+(defn html-escape [content]
+  (string/escape content {\& "&amp;"
+                          \< "&lt;"
+                          \> "&gt;"
+                          \" "&quot;"
+                          \' "&#x27;"
+                          \/ "&#x2F;"}))
+
+(defn break-newlines [content]
+  (string/replace content "\n" "<br>"))
+
+(defn format-replies [content]
+  (string/replace content " >" "\n>"))
+
+;; https://daringfireball.net/2010/07/improved_regex_for_matching_urls
+(def url-pattern #"(?i)\b(?:(?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(?:(?:[^\s()<>]+|(?:\(?:[^\s()<>]+\)))*\))+(?:\(?:(?:[^\s()<>]+|(?:\(?:[^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'\".,<>?«»“”‘’]))")
+
+(defn linkify [url]
+   (str "<a href=\"" url "\">" url "</a>"))
+
+(defn segment-text-url [content]
+  (let [url (re-find url-pattern content)]
+    (cond
+      (not (nil? url))
+      (let [url-start-index (string/index-of content url)
+            url-end-index (+ url-start-index (.length url))
+            text-sub (subs content 0 url-start-index)
+            url-sub (subs content url-start-index url-end-index)
+            rest (subs content url-end-index)]
+        (concat
+          (if (empty? text-sub)
+            [[:url url-sub]]
+            [[:text text-sub] [:url url-sub]])
+          (segment-text-url rest)))
+      (not (empty? content)) (list [:text content])
+      :else '())))
+
+(defn reformat-article [article]
+  (let [segments (segment-text-url article)]
+    (reduce
+      (fn [formatted-content [seg-type seg]]
+          (cond
+            (= seg-type :text)
+            (str formatted-content
+                 ((comp break-newlines html-escape format-replies) seg))
+            (= seg-type :url)
+            (str formatted-content (linkify seg))))
+      ""
+      segments)))

--- a/src/more_speech/ui/swing/article_panel.clj
+++ b/src/more_speech/ui/swing/article_panel.clj
@@ -50,11 +50,17 @@
 (defn bold-label [s]
   (label :text s :font config/bold-font))
 
+(def editor-pane-stylesheet
+  "<style>
+    body {font-family: courier; font-style: normal; font-size: 14; font-weight: lighter;}
+    a {color: inherit; text-decoration: none;}</style>")
+
 (defn make-article-area []
   (editor-pane
-    :font config/default-font
+    :content-type "text/html"
     :editable? false
-    :id :article-area))
+    :id :article-area
+    :text editor-pane-stylesheet))
 
 (declare go-back go-forward)
 
@@ -101,8 +107,7 @@
     (swing-util/clear-popup relays-popup)
     (config! relays-popup :items (:relays event))
     (text! article-area (formatters/reformat-article
-                          (formatters/replace-references event)
-                          config/article-width))
+                          (formatters/replace-references event)))
     (text! (select main-frame [:#author-name-label])
            (format-user (:pubkey event)))
     (text! (select main-frame [:#author-id-label])

--- a/src/more_speech/ui/swing/main_window.clj
+++ b/src/more_speech/ui/swing/main_window.clj
@@ -1,12 +1,14 @@
 (ns more-speech.ui.swing.main-window
   (:require [clojure.core.async :as async]
+            [clojure.java.browse :as browse]
             [more-speech.nostr.events :as events]
             [more-speech.ui.swing.article-tree :as article-tree]
             [more-speech.ui.swing.article-panel :as article-panel]
             [more-speech.ui.swing.relay-panel :as relay-panel]
             [more-speech.ui.swing.ui-context :refer :all])
   (:use [seesaw core])
-  (:import (javax.swing Timer)))
+  (:import (javax.swing Timer)
+           (javax.swing.event HyperlinkEvent$EventType)))
 
 (defrecord seesawHandler []
   events/event-handler
@@ -54,11 +56,15 @@
       (article-tree/select-article (keyword tab-name) (last selections)))
     ))
 
+(defn open-link [e]
+  (if (= HyperlinkEvent$EventType/ACTIVATED (.getEventType e))
+         (browse/browse-url (.getURL e))))
 
 (defn make-main-window []
   (let [main-frame (frame :title "More Speech" :size [1500 :by 1000])
         _ (swap! ui-context assoc :frame main-frame)
         article-area (article-panel/make-article-area)
+        _ (listen article-area :hyperlink open-link)
         header-tab-panel (tabbed-panel :tabs (make-tabs) :id :header-tab-panel)
         _ (listen header-tab-panel :selection select-tab)
         relay-panel (relay-panel/make-relay-panel)


### PR DESCRIPTION
Add support to detect and hyperlink URLs in the article window.

Changes:
- Changed article window's editor-pane type to "text/html". This lets us listen to hyperlink events.
- Article content is HTML escaped before displaying. So the content is displayed as is like in plain text.
- URLs are identified using a regex [pattern](https://daringfireball.net/2010/07/improved_regex_for_matching_urls). It's not entirely accurate but worked for most cases.
- `reformat-article` is removed since the article window uses HTML. It also wraps text dynamically when the application window is resized.