### PR TITLE
Fix locale for `file-name-from-day`

### DIFF
--- a/src/more_speech/data_storage.clj
+++ b/src/more_speech/data_storage.clj
@@ -6,7 +6,7 @@
             [more-speech.ui.swing.tabs :as tabs]
             [more-speech.user-configuration :as user-configuration]
             [clojure.string :as string])
-  (:import (java.util Date TimeZone)
+  (:import (java.util Date TimeZone Locale)
            (java.text SimpleDateFormat)))
 
 
@@ -76,7 +76,7 @@
 (defn file-name-from-day [day]
   (let [time (* day 86400000)
         date (Date. (long time))
-        date-format (SimpleDateFormat. "ddMMMyy")]
+        date-format (SimpleDateFormat. "ddMMMyy" Locale/US)]
     (.setTimeZone date-format (TimeZone/getTimeZone "UTC"))
     (str day "-" (.format date-format date))
     ))


### PR DESCRIPTION
The following tests were failing because the function `file-name-from-day` insisted in adding a dot (`.`) to the month:

 - data-storage partition-messages-by-day calculates file name from day
 - The Migrator migration 7 break message-file into daily files breaks up message-file and deletes it

I was running the tests in my machine with local set to Canada (en_CA.UTF-8).

Considering that it is for an automated file name creation, maybe full consideration of locale is not necessary. So, fixing it to the expected output by the Original Author makes sense.

FYI: This was the output of my tests when failing:

```
$ lein spec
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
.F..changed-to-tmp
......Migrating to level 2.
Migrating to level 3.
..A private and public key have been generated for you.
Your temporary user name is:  more-speech-31944
Please edit private/keys to change it.
{:name "more-speech-31944", :about "", :picture "", :public-key "522d87fb02bc24a8ef49d7ce40e0d02700f2562ef4fcbaf9884a96a51d684e00", :private-key "f770e81cdbeab3eeb3e9bed2dd6fa462b0278fb361a771c1bdd9d1ddca9da215"}
........writing "0-01Jan.70"
writing "1-02Jan.70"
F.......adding-relay "someurl"
adding-relay "anotherurl"
............................"unclebob408"
.......................................................................................................

Failures:

  1) data-storage partition-messages-by-day calculates file name from day
     Expected: "0-01Jan70"
          got: "0-01Jan.70" (using =)
     /home/monkey/Projects/Playground/more-speech/spec/more_speech/data_storage_spec.clj:31

  2) The Migrator migration 7 break message-file into daily files breaks up message-file and deletes it
     Expected truthy but was: false
     /home/monkey/Projects/Playground/more-speech/spec/more_speech/migrator_spec.clj:203

Finished in 5.14545 seconds
159 examples, 2 failures
Subprocess failed
```