### PR TITLE
Get open-link to work (when user clicks on a URL).

### DIFF
--- a/src/more_speech/ui/swing/main_window.clj
+++ b/src/more_speech/ui/swing/main_window.clj
@@ -29,7 +29,7 @@
 
 (defn open-link [e]
   (when (= HyperlinkEvent$EventType/ACTIVATED (.getEventType e))
-         (browse/browse-url (.getURL e))))
+         (browse/browse-url (str (.getURL e)))))
 
 (defn make-main-window []
   (let [event-context @(:event-context @ui-context)


### PR DESCRIPTION
`open-link` didn't do anything except print an error message when I tried clicking on links in the article window. I assume this is because browse/browse-url expects a string and .getURL returns some kind of url object, and the two are not compatible.

The error message was:
  Exception in thread "AWT-EventQueue-0" java.lang.ClassCastException:
  class java.net.URL cannot be cast to class java.lang.String (java.net.URL and java.lang.String are in module java.base of loader 'bootstrap')
	at clojure.java.browse$open_url_in_browser.invokeStatic(browse.clj:50)
	at clojure.java.browse$browse_url.invokeStatic(browse.clj:74)
	at clojure.java.browse$browse_url.invoke(browse.clj:66)

(This occurred with Clojure 1.10.3, Java 18.0.1.1., Windows 10)