### PR TITLE
fix: ISO hours are range [0..23]

### DIFF
--- a/spec/more_speech/ui/formatters_spec.clj
+++ b/spec/more_speech/ui/formatters_spec.clj
@@ -176,7 +176,7 @@
           event {:pubkey 1 :created-at created-at
                  :relays relays :tags tags :content "Hello #[0]."}]
       (should=
-        ">From: (user-1) at 07/05/22 24:00:00 on relay-1\n>---------------\n>Hello @user-1."
+        ">From: (user-1) at 07/05/22 00:00:00 on relay-1\n>---------------\n>Hello @user-1."
         (format-reply event))))
 
   (it "formats a reply to a DM"
@@ -189,7 +189,7 @@
           event {:pubkey 1 :created-at created-at :dm true
                  :relays relays :tags tags :content "Hello #[0]."}]
       (should=
-        "D @user-1\n>From: (user-1) at 07/05/22 24:00:00 on relay-1\n>---------------\n>Hello @user-2."
+        "D @user-1\n>From: (user-1) at 07/05/22 00:00:00 on relay-1\n>---------------\n>Hello @user-2."
         (format-reply event)))
     )
 

--- a/src/more_speech/ui/formatter_util.clj
+++ b/src/more_speech/ui/formatter_util.clj
@@ -6,7 +6,7 @@
 (defn format-time [time]
   (let [time (* time 1000)
         date (Date. (long time))]
-    (.format (SimpleDateFormat. "MM/dd/yy kk:mm:ss") date))
+    (.format (SimpleDateFormat. "MM/dd/yy HH:mm:ss") date))
   )
 
 (defn make-date [date-string]


### PR DESCRIPTION
Time should follow ISO standards and hours are in range between 0-23 i.e. `00:32:10` not `24:32:10`.

More about this:
https://en.wikipedia.org/wiki/ISO_8601