### PR TITLE
README: include non-headless openjdk-17-jdk in run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ write tests for the code you write, and follow the conventions I've started here
 Sample commands for Debian:
 
 ```
-sudo apt install clojure leiningen
+sudo apt install clojure leiningen openjdk-17-jdk
 
 git clone https://github.com/unclebob/more-speech
 cd more-speech


### PR DESCRIPTION
My installation of Debian bookworm only had the `openjdk-17-jdk-headless` package - and even then, it was possibly installed as a dependency of other packages I installed.